### PR TITLE
ignoring vscode folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ Users
 .settings
 .classpath
 .project
+
+# VSCODE
+.vscode/


### PR DESCRIPTION
I'm adding the vscode to the ignored files so we have an editor parity between Eclipse and Visual Studio Code.